### PR TITLE
chore: replace redis with valkey

### DIFF
--- a/cart/redis/infrastructure/redisStorage_test.go
+++ b/cart/redis/infrastructure/redisStorage_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"flamingo.me/flamingo-commerce-contrib/cart/redis/infrastructure"
 	cartDomain "flamingo.me/flamingo-commerce/v3/cart/domain/cart"
 	"flamingo.me/flamingo/v3/framework/flamingo"
 	"github.com/go-test/deep"
@@ -19,6 +18,8 @@ import (
 	"github.com/stvp/tempredis"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
+
+	"flamingo.me/flamingo-commerce-contrib/cart/redis/infrastructure"
 )
 
 const (
@@ -81,9 +82,11 @@ func startUpDockerRedis(t *testing.T) (func(), string, redis.UniversalClient) {
 
 	ctx := context.Background()
 	req := testcontainers.ContainerRequest{
-		Image:        "redis:latest",
+		Image:        "valkey/valkey:7",
 		ExposedPorts: []string{"6379/tcp"},
-		WaitingFor:   wait.ForLog("Ready to accept connections"),
+		WaitingFor: wait.ForAll(
+			wait.ForLog("Ready to accept connections"),
+			wait.ForListeningPort("6379/tcp")),
 	}
 
 	redisC, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{

--- a/cart/redis/integrationtest/helper/helper.go
+++ b/cart/redis/integrationtest/helper/helper.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"flamingo.me/dingo"
-	"flamingo.me/flamingo-commerce-contrib/cart/redis"
 	"flamingo.me/flamingo-commerce/v3/breadcrumbs"
 	"flamingo.me/flamingo-commerce/v3/cart"
 	"flamingo.me/flamingo-commerce/v3/category"
@@ -41,6 +40,8 @@ import (
 	"flamingo.me/graphql"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
+
+	"flamingo.me/flamingo-commerce-contrib/cart/redis"
 )
 
 // modulesDemoProject return slice of modules that we want to have in our example app for testing
@@ -85,9 +86,11 @@ var redisC testcontainers.Container
 func startUpDockerRedis(configMap config.Map) config.Map {
 	ctx := context.Background()
 	req := testcontainers.ContainerRequest{
-		Image:        "redis:latest",
+		Image:        "valkey/valkey:7",
 		ExposedPorts: []string{"6379/tcp"},
-		WaitingFor:   wait.ForLog("Ready to accept connections"),
+		WaitingFor: wait.ForAll(
+			wait.ForLog("Ready to accept connections"),
+			wait.ForListeningPort("6379/tcp")),
 	}
 
 	var err error


### PR DESCRIPTION
This PR replaces docker container image for integration tests to Valkey instead of Redis